### PR TITLE
Only include `docprovider` and `docprovider-extension` in sdist

### DIFF
--- a/projects/jupyter-docprovider/pyproject.toml
+++ b/projects/jupyter-docprovider/pyproject.toml
@@ -45,7 +45,8 @@ artifacts = ["jupyter_docprovider/labextension"]
 exclude = ["/.github", "/binder", "node_modules"]
 
 [tool.hatch.build.targets.sdist.force-include]
-"../../packages" = "packages"
+"../../packages/docprovider" = "packages/docprovider"
+"../../packages/docprovider-extension" = "packages/docprovider-extension"
 
 [tool.hatch.build.targets.wheel.shared-data]
 "jupyter_docprovider/labextension" = "share/jupyter/labextensions/@jupyter/docprovider-extension"


### PR DESCRIPTION
This should reduce the sdist size for `jupyter-docprovider`